### PR TITLE
Add pagination to table component

### DIFF
--- a/cms/src/components/common/AcTable.spec.ts
+++ b/cms/src/components/common/AcTable.spec.ts
@@ -79,4 +79,29 @@ describe("AcTable", () => {
         expect(wrapper.emitted("update:sortBy")![0]).toEqual(["year_group"]);
         expect(wrapper.emitted("update:sortDirection")![0]).toEqual(["ascending"]);
     });
+
+    it("can paginate the items", async () => {
+        const wrapper = mount(AcTable, {
+            props: {
+                columns,
+                items,
+                paginate: true,
+                itemsPerPage: 1,
+                currentPage: 1,
+                "onUpdate:currentPage": (e) => wrapper.setProps({ currentPage: e }),
+            },
+        });
+
+        expect(wrapper.text()).toContain("Ada Lovelace");
+        expect(wrapper.text()).not.toContain("Firmus Piett");
+        expect(wrapper.text()).toContain("Go to page 1");
+        expect(wrapper.text()).toContain("Go to page 2");
+
+        await wrapper.findAll("button.page")[1].trigger("click");
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.emitted("update:currentPage")![0]).toEqual([2]);
+        expect(wrapper.text()).not.toContain("Ada Lovelace");
+        expect(wrapper.text()).toContain("Firmus Piett");
+    });
 });

--- a/cms/src/components/common/AcTable.spec.ts
+++ b/cms/src/components/common/AcTable.spec.ts
@@ -81,7 +81,7 @@ describe("AcTable", () => {
     });
 
     it("can paginate the items", async () => {
-        const wrapper = mount(AcTable, {
+        const wrapper: any = mount(AcTable, {
             props: {
                 columns,
                 items,

--- a/cms/src/components/common/AcTable.vue
+++ b/cms/src/components/common/AcTable.vue
@@ -16,19 +16,45 @@ type Props = {
     items: Item[];
     sortBy?: string;
     sortDirection?: SortDirection;
+    paginate?: boolean;
+    itemsPerPage?: number;
+    currentPage?: number;
 };
 
 const props = withDefaults(defineProps<Props>(), {
     sortDirection: "descending",
+    paginate: false,
+    itemsPerPage: 25,
+    currentPage: 1,
 });
-const { columns, items, sortBy, sortDirection } = toRefs(props);
+const { columns, items, paginate, sortBy, sortDirection, currentPage, itemsPerPage } =
+    toRefs(props);
 
-const emit = defineEmits(["update:sortBy", "update:sortDirection"]);
+const emit = defineEmits(["update:sortBy", "update:sortDirection", "update:currentPage"]);
 
 function getField(item: Item, columnKey: string) {
     const segments = columnKey.split(".");
     return segments.reduce((obj, key) => obj[key], item);
 }
+
+const paginateStart = computed(() => {
+    return (currentPage.value - 1) * itemsPerPage.value;
+});
+const paginateEnd = computed(() => {
+    return Math.min(paginateStart.value + itemsPerPage.value, items.value.length);
+});
+
+const paginatedItems = computed(() => {
+    if (!paginate.value) {
+        return sortedItems.value;
+    }
+
+    return sortedItems.value.slice(paginateStart.value, paginateEnd.value);
+});
+
+const pages = computed(() => {
+    return Math.round(items.value.length / itemsPerPage.value);
+});
 
 const sortedItems = computed(() => {
     if (sortBy?.value == undefined) {
@@ -55,6 +81,10 @@ const sortedItems = computed(() => {
         return 0;
     });
 });
+
+function setCurrentPage(page: number) {
+    emit("update:currentPage", page);
+}
 
 function sort(column: Column) {
     if (column.sortable === false) {
@@ -120,7 +150,7 @@ function sort(column: Column) {
                     </tr>
                 </thead>
                 <tbody class="divide-y divide-gray-200 bg-white">
-                    <tr v-for="(item, key) in sortedItems" :key="key">
+                    <tr v-for="(item, key) in paginatedItems" :key="key">
                         <td
                             v-for="(column, index) in columns"
                             :key="column.key"
@@ -142,6 +172,38 @@ function sort(column: Column) {
                         </td>
                     </tr>
                 </tbody>
+                <tfoot class="bg-gray-50 text-sm" v-if="paginate">
+                    <tr>
+                        <td :colspan="items.length - 1" class="py-3 pl-4 pr-3 sm:pl-6">
+                            <div class="flex items-center justify-between">
+                                <div class="text-gray-700">
+                                    Showing
+                                    <span class="font-medium">{{ paginateStart + 1 }}</span>
+                                    to
+                                    <span class="font-medium">{{ paginateEnd }}</span>
+                                    of
+                                    <span class="font-medium">{{ items.length }}</span>
+                                    results
+                                </div>
+                                <div>
+                                    <button
+                                        v-for="page in pages"
+                                        :key="page"
+                                        @click="setCurrentPage(page)"
+                                        class="page mx-0.5 cursor-pointer rounded px-2.5 py-1 text-gray-800 hover:bg-gray-200 active:bg-gray-300"
+                                        :class="{
+                                            'bg-gray-200 ring-1 ring-inset ring-gray-300/80':
+                                                page == currentPage,
+                                        }"
+                                    >
+                                        <span class="sr-only">Go to page</span>
+                                        {{ page }}
+                                    </button>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </tfoot>
             </table>
         </div>
     </div>

--- a/cms/src/components/common/AcTable.vue
+++ b/cms/src/components/common/AcTable.vue
@@ -192,7 +192,7 @@ function sort(column: Column) {
                                         @click="setCurrentPage(page)"
                                         class="page mx-0.5 cursor-pointer rounded px-2.5 py-1 text-gray-800 hover:bg-gray-200 active:bg-gray-300"
                                         :class="{
-                                            'bg-gray-200 ring-1 ring-inset ring-gray-300/80':
+                                            'bg-gray-200 font-medium text-gray-900 ring-1 ring-inset ring-gray-300/80':
                                                 page == currentPage,
                                         }"
                                     >

--- a/cms/src/components/common/AcTable.vue
+++ b/cms/src/components/common/AcTable.vue
@@ -175,7 +175,9 @@ function sort(column: Column) {
                 <tfoot class="bg-gray-50 text-sm" v-if="paginate">
                     <tr>
                         <td :colspan="items.length - 1" class="py-3 pl-4 pr-3 sm:pl-6">
-                            <div class="flex items-center justify-between">
+                            <div
+                                class="flex flex-row-reverse items-center justify-between sm:flex-row"
+                            >
                                 <div class="text-gray-700">
                                     Showing
                                     <span class="font-medium">{{ paginateStart + 1 }}</span>

--- a/cms/src/pages/internal/ComponentSandbox.vue
+++ b/cms/src/pages/internal/ComponentSandbox.vue
@@ -25,6 +25,7 @@ const selectedLanguage = ref("sw");
 // Table
 const sortBy = ref(undefined);
 const sortDirection = ref(undefined);
+const currentPage = ref(1);
 const columns = [
     {
         text: "Title",
@@ -81,6 +82,16 @@ const items = [
             fra: "success",
             swa: "info",
             nya: "success",
+        },
+    },
+    {
+        id: 5,
+        title: "An unexpected journey",
+        translations: {
+            eng: "success",
+            fra: "info",
+            swa: "info",
+            nya: "default",
         },
     },
 ];
@@ -185,10 +196,13 @@ const items = [
                 <template #footer>With footer</template>
             </AcCard>
 
-            <AcCard padding="none" title="Table">
+            <AcCard padding="none">
                 <AcTable
                     :columns="columns"
                     :items="items"
+                    paginate
+                    v-model:currentPage="currentPage"
+                    :itemsPerPage="2"
                     v-model:sortBy="sortBy"
                     v-model:sortDirection="sortDirection"
                 >


### PR DESCRIPTION
![image](https://github.com/bccsa/ac-app/assets/39056299/fd5e0de5-33eb-4d0c-9efe-43c02f1a56be)

One notable feature missing is that normally when you have a lot of pages it doesn't show all the page numbers. But since we probably won't encounter that for a while I thought it acceptable to only do that later.