### PR TITLE
Only update document if it has changed

### DIFF
--- a/api/jest.teardown.ts
+++ b/api/jest.teardown.ts
@@ -1,5 +1,13 @@
-import { destroyAllDocs } from "./src/db/db.seedingFunctions";
+// import { destroyAllDocs } from "./src/db/db.seedingFunctions";
 
 export default async function () {
-    await destroyAllDocs();
+    // await destroyAllDocs();
+    // Note: Destroying documents does not delete them from the database, but marks them as deleted.
+    // This does not work well with testing where we reuse the testing database (i.e. local testing
+    // on your computer) as CouchDB / nano complains that the document is deleted, and hence cannot
+    // be created. In real life scenarios a recreating a deleted document should never occur, and
+    // if it does this would be an exception that should be logged to an error log instead of
+    // being processed.
+    // It therefore does not work to destroy our testing data set for local testing - the developer
+    // can rather delete the testing database on his computer once in a while if it gets too big.
 }

--- a/api/src/db/db.service.spec.ts
+++ b/api/src/db/db.service.spec.ts
@@ -164,6 +164,59 @@ describe("DbService", () => {
         expect(docCount).toBe(8);
     });
 
+    it("can detect that a document is exactly the same as the document in the database", async () => {
+        const res: any = await service.upsertDoc({
+            _id: "group-private-content",
+            type: "group",
+            updatedTimeUtc: 3,
+            name: "Private Content",
+            acl: [
+                {
+                    type: "post",
+                    groupId: "group-private-users",
+                    permission: ["view"],
+                },
+                {
+                    type: "tag",
+                    groupId: "group-private-users",
+                    permission: ["view"],
+                },
+                {
+                    type: "post",
+                    groupId: "group-private-editors",
+                    permission: ["view", "edit", "translate", "publish"],
+                },
+                {
+                    type: "tag",
+                    groupId: "group-private-editors",
+                    permission: ["view", "translate", "assign"],
+                },
+                {
+                    type: "group",
+                    groupId: "group-private-editors",
+                    permission: ["view", "assign"],
+                },
+            ],
+        });
+
+        expect(res).toBe("passed document equal to existing database document");
+    });
+
+    it("can handle simultaneous updates to a single document", async () => {
+        const pList = new Array<Promise<any>>();
+
+        for (let index = 0; index < 50; index++) {
+            pList.push(service.upsertDoc({ _id: "simultaneousTest", testVal: index }));
+        }
+
+        let res: boolean = false;
+        await Promise.all(pList);
+
+        // if we got past this point without an exception, the test was successful
+        res = true;
+        expect(res).toBe(true);
+    });
+
     // TODO: Enable after adding Mango Indexes
     // it("does not return database warnings", async () => {
     //     const res: any = await service.getDocs("", {


### PR DESCRIPTION
Prevent updates to database on unchanged documents to prevent re-indexing (especially when the docs are design docs / views).

Other issues fixed in this PR:
- handle duplicate updating of documents correctly (this can happen when two processes are trying to update the same document simultaneously)
- Remove teardown logic deleting all documents in database from test to avoid complications on re-creating deleted documents in database interface logic testing.